### PR TITLE
Otel metric example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note the application implementation is deliberately simple (eg System.out instea
 
 ## Plugin sub-project
 
-The plugin consists of a [single file](plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleHttpServerInstrumentation.java) holding the custom instrumentation, several classes for regression testing, and a pom that builds the correct plugin jar. The details of the plugin project are explained in the articles [creating the instrumentation](https://www.elastic.co/blog/create-your-own-instrumentation-with-the-java-agent-plugin) and [regression testing it](https://www.elastic.co/blog/create-your-own-instrumentation-with-the-java-agent-plugin).
+The plugin consists of [one file](plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleHttpServerInstrumentation.java) holding the custom tracing instrumentation, [one file](plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMetricsInstrumentation.java) holding custom metrics instrumentation, several classes for regression testing, and a pom that builds the correct plugin jar. The details of the plugin project are explained in the articles [creating the instrumentation](https://www.elastic.co/blog/create-your-own-instrumentation-with-the-java-agent-plugin) and [regression testing it](https://www.elastic.co/blog/create-your-own-instrumentation-with-the-java-agent-plugin).
 
 ## Building
 
@@ -47,7 +47,7 @@ Each sub-project can also be separately built the same way (changing to the sub-
 
 ## Running
 
-You need an Elastic APM Java Agent jar (the latest version is recommended, but at least version 1.31.0). Additionally an Elastic APM server is recommended, though not required (communications to the server will be dropped if it's unavailable).
+You need an Elastic APM Java Agent jar (the latest version is recommended, but at least version 1.31.0 to instrument traces and at least 1.39.0 to instrument metrics). Additionally an Elastic APM server is recommended, though not required (communications to the server will be dropped if it's unavailable).
 
 The full set of example run instructions below are also available as a batch script in the project root directory, in file runExamples.bash/runExamples.bat
 

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>co.elastic.apm</groupId>
   <artifactId>application</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.0.3-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
   <version>0.0.3-SNAPSHOT</version>
 
   <properties>
-    <version.elastic-agent>1.38.0</version.elastic-agent>
+    <version.elastic-agent>1.39.0</version.elastic-agent>
   </properties>
 
   <dependencies>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -2,10 +2,10 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>co.elastic.apm</groupId>
   <artifactId>plugin</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.0.3-SNAPSHOT</version>
 
   <properties>
-    <version.elastic-agent>1.31.0</version.elastic-agent>
+    <version.elastic-agent>1.38.0</version.elastic-agent>
   </properties>
 
   <dependencies>
@@ -20,7 +20,7 @@
 	<dependency>
 	    <groupId>io.opentelemetry</groupId>
 	    <artifactId>opentelemetry-api</artifactId>
-	    <version>1.0.0</version>
+	    <version>1.25.0</version>
 	</dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>co.elastic.apm</groupId>
       <artifactId>application</artifactId>
-      <version>0.0.2-SNAPSHOT</version>
+      <version>0.0.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <!-- The mock APM server provides JSON structured information -->

--- a/plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMetricsInstrumentation.java
+++ b/plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMetricsInstrumentation.java
@@ -54,7 +54,8 @@ public class ExampleMetricsInstrumentation extends ElasticApmInstrumentation {
      */
     public static class AdviceClass {
         /**
-         * At initialization, we register the with the OpenTelemetry registry by
+         * At initialization, we register with the OpenTelemetry registry by
+
          * creating a meter, a page count metric (`page_views`) which will be available
          * in the Elastic APM metrics views.
          *

--- a/plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMetricsInstrumentation.java
+++ b/plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMetricsInstrumentation.java
@@ -47,7 +47,8 @@ public class ExampleMetricsInstrumentation extends ElasticApmInstrumentation {
      * it needs to be applied, ie when the above matchers ({@code getTypeMatcher}
      * and {@code getMethodMatcher}) have been matched
      *
-     * The ELastic APM Java agent provides the OpenTelemetry metrics capability -
+     * The Elastic APM Java agent provides the OpenTelemetry metrics capability -
+
      * the agent fully implements the OpenTelemetry metrics framework. See
      * https://www.elastic.co/guide/en/apm/agent/java/master/opentelemetry-bridge.html#otel-metrics
      */

--- a/plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMicrometerMetricsInstrumentation.java
+++ b/plugin/src/main/java/co/elastic/apm/example/webserver/plugin/ExampleMicrometerMetricsInstrumentation.java
@@ -1,13 +1,17 @@
 package co.elastic.apm.example.webserver.plugin;
 
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
-import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.metrics.LongCounter;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.CountingMode;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -24,7 +28,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
  * it gets loaded, and  we'll instrument that method using
  * the inner AdviceClass class below
  */
-public class ExampleMetricsInstrumentation extends ElasticApmInstrumentation {
+public class ExampleMicrometerMetricsInstrumentation extends ElasticApmInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return named("co.elastic.apm.example.webserver.ExampleBasicHttpServer");
@@ -47,32 +51,49 @@ public class ExampleMetricsInstrumentation extends ElasticApmInstrumentation {
      * it needs to be applied, ie when the above matchers ({@code getTypeMatcher}
      * and {@code getMethodMatcher}) have been matched
      *
-     * The ELastic APM Java agent provides the OpenTelemetry metrics capability -
-     * the agent fully implements the OpenTelemetry metrics framework. See
-     * https://www.elastic.co/guide/en/apm/agent/java/master/opentelemetry-bridge.html#otel-metrics
+     * The ELastic APM Java agent provides a metrics capability using
+     * the Micrometer framework, see
+     * https://www.elastic.co/guide/en/apm/agent/java/current/metrics.html#metrics-micrometer
      */
     public static class AdviceClass {
         /**
-         * At initialization, we register the with the OpenTelemetry registry by
-         * creating a meter, a page count metric (`page_views`) which will be available
+         * At method entry, we want to ensure that we've registered the
+         * with the micrometer registry (only needed to do once, so
+         * it's guarded with a boolean), then we'll increment
+         * a page count metric, `page_count` which will be available
          * in the Elastic APM metrics views.
          *
          * For details on the Byte Buddy advice annotation used here,
          * see the ExampleHttpServerInstrumentation$AdviceClass
          * class and it's `onEnterHandle` method javadoc, in this package.
          */
-        private static volatile LongCounter pageViewCounter;
-
+        private static volatile boolean metricWasAdded = false;
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static void onEnterHandle() {
-            if (pageViewCounter == null) {
-                pageViewCounter = GlobalOpenTelemetry
-                        .getMeter("ExampleHttpServer")
-                        .counterBuilder("page_views")
-                        .setDescription("Page view count")
-                        .build();
+            if (!metricWasAdded) {
+                Metrics.addRegistry(new SimpleMeterRegistry(new SimpleConfig() {
+
+                    @Override
+                    public CountingMode mode() {
+                        // to report the delta since the last report
+                        // this makes building dashboards a bit easier
+                        return CountingMode.STEP;
+                    }
+
+                    @Override
+                    public Duration step() {
+                        // the duration should match metrics_interval, which defaults to 30s
+                        return Duration.ofSeconds(30);
+                    }
+
+                    @Override
+                    public String get(String key) {
+                        return null;
+                    }
+                }, Clock.SYSTEM));
+                metricWasAdded = true;
             }
-            pageViewCounter.add(1);
+            Metrics.counter("page_counter").increment();
         }
     }
 }

--- a/plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,2 +1,3 @@
 co.elastic.apm.example.webserver.plugin.ExampleHttpServerInstrumentation
 co.elastic.apm.example.webserver.plugin.ExampleMetricsInstrumentation
+co.elastic.apm.example.webserver.plugin.ExampleMicrometerMetricsInstrumentation

--- a/plugin/src/test/java/co/elastic/apm/plugin/AbstractInstrumentationTest.java
+++ b/plugin/src/test/java/co/elastic/apm/plugin/AbstractInstrumentationTest.java
@@ -1,6 +1,7 @@
 package co.elastic.apm.plugin;
 
 import co.elastic.apm.attach.ElasticApmAttacher;
+import co.elastic.apm.example.webserver.plugin.ExampleHttpServerInstrumentation;
 import co.elastic.apm.mock.MockApmServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,6 +28,12 @@ public class AbstractInstrumentationTest {
         setProperty("elastic.apm.api_request_size", "100b"); //flush quickly - inadvisably short outside tests
         setProperty("elastic.apm.report_sync", "true"); //DON'T USE EXCEPT IN TEST!!
         setProperty("elastic.apm.metrics_interval", "1s"); //flush metrics quickly - inadvisably short outside tests
+
+        setProperty("elastic.apm.log_level", "DEBUG");
+        //Setting this makes the agent startup faster
+        String instrumentations = "micrometer, opentelemetry, opentelemetry-metrics, "+String.join(", ",
+                new ExampleHttpServerInstrumentation().getInstrumentationGroupNames());
+        setProperty("elastic.apm.enable_instrumentations", instrumentations);
 
         //Start the agent
         ElasticApmAttacher.attach();

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>co.elastic.apm</groupId>
     <artifactId>apm-agent-java-plugin-example</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>pom</packaging>
 
     <name>APM Java Agent Plugin Example</name>
@@ -36,7 +36,7 @@
     </developers>
 
     <prerequisites>
-        <maven>3.8.3</maven>
+        <maven>3.8.8</maven>
     </prerequisites>
 
     <modules>


### PR DESCRIPTION
Changes needed for the blog "How to produce custom metrics without app code changes using the Java Agent Plugin".

Note the old `ExampleMetricsInstrumention` class was renamed `ExampleMicrometerMetricsInstrumentation`, and a new OTel implementation put into `ExampleMetricsInstrumention`, so for reviewing it's simplest to just read `ExampleMetricsInstrumention` as new rather than a diff, (and `ExampleMicrometerMetricsInstrumentation` is just a rename)